### PR TITLE
Avoid reloading from the written cache in debug mode

### DIFF
--- a/src/Provider/TranslationProvider.php
+++ b/src/Provider/TranslationProvider.php
@@ -31,13 +31,14 @@ class TranslationProvider implements ServiceProviderInterface
 
                     $cacheFile = $container['translation_cache'] . '/saxulum-translation.php';
                     if ($container['debug'] || !file_exists($cacheFile)) {
+                        $translationMap = $container['translation_search']();
                         file_put_contents(
                             $cacheFile,
-                            '<?php return ' . var_export($container['translation_search'](), true) . ';'
+                            '<?php return ' . var_export($translationMap, true) . ';'
                         );
+                    } else {
+                        $translationMap = require $cacheFile;
                     }
-
-                    $translationMap = require $cacheFile;
                 } else {
                     $translationMap = $container['translation_search']();
                 }


### PR DESCRIPTION
It's more efficient and especially it avoids race conditions where the file is being rewritten while another process requires it.
